### PR TITLE
[HACK:] Quirks for sddm delay

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lindroid-quirks (1.3) stable; urgency=low
+
+  * Adding quirks for sddm delay hack
+
+ -- RealJohnGalt <johngaltfirstrun@gmail.com>  Tue, 11 Aug 2025 12:46:00 +0002
+
 lindroid-quirks (1.2) stable; urgency=low
 
   * Adding quirks for lindroid drm to sdm and profile.d

--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,7 @@
 etc/udev/rules.d/* lib/udev/rules.d/
 etc/sddm.conf.d/* etc/sddm.conf.d/
 etc/systemd/logind.conf.d/lindroid.conf /etc/systemd/logind.conf.d/
+etc/systemd/system/sddm.service.d/override.conf etc/systemd/system/sddm.service.d/
 etc/profile.d/* etc/profile.d/
 libtls-padding/libtls-padding.so usr/lib/
 libtls-padding/ld_preload_tls_padding.sh etc/profile.d/

--- a/etc/systemd/system/sddm.service.d/override.conf
+++ b/etc/systemd/system/sddm.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/sleep 10


### PR DESCRIPTION
SDDM start is inconsistent, 10s was found to always successfully start SDDM at container start.