### PR TITLE
set KWIN_DRM_DEVICES to the by-path one, which is consistent between multiple devices

### DIFF
--- a/etc/profile.d/kwin-lindroid-hacks.sh
+++ b/etc/profile.d/kwin-lindroid-hacks.sh
@@ -4,4 +4,4 @@ export KWIN_COMPOSE=O2ES
 export GBM_BACKEND=hybris
 export __GLX_VENDOR_LIBRARY_NAME=libhybris
 export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_libhybris.json
-export KWIN_DRM_DEVICES=/dev/dri/card1
+export KWIN_DRM_DEVICES=/dev/dri/by-path/platform-evdi-lindroid.0-card

--- a/etc/sddm.conf.d/plasma-wayland.conf
+++ b/etc/sddm.conf.d/plasma-wayland.conf
@@ -1,6 +1,6 @@
 [General]
 DisplayServer=wayland
-GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=xdg-shell,LD_PRELOAD=/usr/lib/libtls-padding.so,KWIN_DRM_USE_MODIFIERS=0,KWIN_DRM_NO_AMS=1,KWIN_COMPOSE=O2ES,KWIN_DRM_DEVICES=/dev/dri/card1,GBM_BACKEND=hybris,__GLX_VENDOR_LIBRARY_NAME=libhybris,__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_libhybris.json
+GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=xdg-shell,LD_PRELOAD=/usr/lib/libtls-padding.so,KWIN_DRM_USE_MODIFIERS=0,KWIN_DRM_NO_AMS=1,KWIN_COMPOSE=O2ES,KWIN_DRM_DEVICES=/dev/dri/by-path/platform-evdi-lindroid.0-card,GBM_BACKEND=hybris,__GLX_VENDOR_LIBRARY_NAME=libhybris,__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_libhybris.json
 
 InputMethod=
 


### PR DESCRIPTION
It is /dev/dri0 on my device. This change should be safe for other devices with lindroid card on card1, but I don't have such a device to test